### PR TITLE
docs: add pygame-ce license reference to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,4 @@ A classic Snake game implementation in Python using pygame-ce.
 
 - **Code**: MIT License
 - **Art Assets**: CC BY 4.0
+- **pygame-ce**: LGPL-2.1 - see [licenses/](licenses/) folder


### PR DESCRIPTION
- Include LGPL-2.1 license reference for pygame-ce dependency